### PR TITLE
packaging: add _static directories to package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,4 +73,9 @@ setup(
     ],
     extras_require=REQS,
     packages=find_namespace_packages(include=["cylc.*"]),
+    package_data={
+        'cylc.sphinx_ext': [
+            '*/_static/*/*'
+        ]
+    }
 )


### PR DESCRIPTION
Package data is currently only available when installed in "editable" mode. Ensure that `_static` resources are included when installed normally.