### PR TITLE
1.0.0: post release fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,29 +7,19 @@ A library of extensions for documenting Cylc projects.
 Installation
 ------------
 
-Install all extensions (but not dependencies):
+Install all extensions (but not dependencies)::
 
-.. code-block:: console
+   $ pip install cylc-sphinx-extensions
 
-   $ pip install git+https://github.com/cylc/cylc-sphinx-extensions.git
+OR all extensions + dependencies for specified extension(s) by name::
 
-OR all extensions + dependencies for specified extension(s) by name:
+   $ pip install cylc-sphinx-extensions.git[cylc_lang]
 
-.. code-block:: console
+OR all extensions + dependencies for all extensions::
 
-   # TODO
-   $ pip install git+https://github.com/cylc/cylc-sphinx-extensions.git[cylc_lang]
+   $ pip install cylc-sphinx-extensions.git[all]
 
-OR all extensions + dependencies for all extensions:
-
-.. code-block:: console
-
-   # TODO
-   $ pip install git+https://github.com/cylc/cylc-sphinx-extensions.git[all]
-
-Note the ``minicylc`` extension requires ``graphviz``:
-
-.. code-block:: console
+Note the ``minicylc`` extension requires ``graphviz``::
 
    # install graphviz from your package manager e.g:
    $ sudo apt-get install -y graphviz
@@ -38,9 +28,7 @@ Note the ``minicylc`` extension requires ``graphviz``:
 Usage
 -----
 
-To use an extension register it in your project's ``conf.py``:
-
-.. code-block:: python
+To use an extension register it in your project's ``conf.py``::
 
    extension = [
        'cylc.sphinx_ext.cylc_lang'
@@ -51,9 +39,7 @@ to activate.
 
 If the ``html_static_path`` configuration is set in your ``conf.py`` you will
 need to move this into a ``setup`` function, otherwise extensions cannot append
-to this path to add their own static resources e.g:
-
-.. code-block:: python
+to this path to add their own static resources e.g::
 
    def setup(app):
        app.config.html_static_path.append('_static')
@@ -66,22 +52,16 @@ Fork and clone ``https://github.com/cylc/cylc-sphinx-extensions.git``.
 
 Extensions are auto-documented from their module docstrings.
 
-Build documentation by running:
-
-.. code-block:: sub
+Build documentation by running::
 
    $ make clean <format>  # e.g. make html
 
 This documentation build serves as a simple test battery (warnings will cause
-it to fail), for everything else there's pytest:
-
-.. code-block:: console
+it to fail), for everything else there's pytest::
 
    $ pytest
 
-For code linting:
-
-.. code-block:: console
+For code linting::
 
    $ pycodestyle .  # python
    $ eslint cylc/   # javascript

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ setup(
     license_file='LICENCE',
     description='Sphinx extensions for documenting Cylc',
     long_description=open('README.rst', 'r').read(),
-    long_description_content_type='text/x-rst',
     install_requires=[
         'sphinx>=2.0.0'
     ],


### PR DESCRIPTION
* Update the README to install from pypi rather than GitHub
* Use basic RST for the README for compatibility with pypi (code-block not available)

Simple documentation change, one review should be sufficient.