### PR TITLE
actions: fix deployment script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
-name: deploy
+name: release
 
-on: [published]
+on: [pull_request]
 
 jobs:
-  test:
+  gh-pages:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -12,14 +12,9 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: '3.7'
-      - name: configure node
-        uses: actions/setup-node@v1
-        with:
-            node-version: '10.x'
       - name: install
         run: |
           pip install -e .[all]
-          npm install -g eslint
           sudo apt-get install -y graphviz
       - name: build
         run: |
@@ -27,5 +22,6 @@ jobs:
       - name: deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GH_PAGES_DEPlOY_KEY }}
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./_build/html
+          publish_branch: gh-pages


### PR DESCRIPTION
I created a [pull request](https://github.com/cylc/cylc-sphinx-extensions/pull/18) to try and force the deployment action to run, unfortunately it failed :(

I've fixed the action here, but I still [can't get it to pass](https://github.com/cylc/cylc-sphinx-extensions/runs/512793601), it fails with the following message:

```
##[error]Action failed with "not found deploy key or tokens"
```

After a bit of poking around, if I replace `${{ secrets.ACTIONS_DEPLOY_KEY }}` with `whatever` it produces an invalid SSH key error message.

So my guess is that `ACTIONS_DEPLOY_KEY` is not being passed to this action so the action is getting a blank `deploy_key`.

My only guess is to try merging the fix then attempt to run the action again in the hope that GitHub will then attempt to provide the secret? Not sure.