### PR TITLE
Conf tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# derived content
+extensions/
+_build/
+
+# python bytecode
+*.py[cod]
+__pycache__/
+
+# vim backup files
+*.sw[op]
+
+# emacs backup files
+*~
+
+# vscode
+.vscode
+
+# coverage
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
+# distutils files
+build
+dist
+MANIFEST
+*.egg-info
+.eggs
+
+# virtualenv
+venv
+
+# mypy
+.mypy_cache/

--- a/cylc/sphinx_ext/cylc_lang/__init__.py
+++ b/cylc/sphinx_ext/cylc_lang/__init__.py
@@ -78,6 +78,9 @@ Sphinx domain for ``cylc`` configurations.
 
         a section called ``bar``.
 
+        Here's a link to :cylc:conf:`this section <my-conf1.rc[bar]>`, note
+        we re-named the target using the sphinx/rst ``name <target>`` syntax.
+
         .. cylc:setting:: pub
 
            a setting called ``pub``

--- a/cylc/sphinx_ext/cylc_lang/__init__.py
+++ b/cylc/sphinx_ext/cylc_lang/__init__.py
@@ -68,7 +68,11 @@ Sphinx domain for ``cylc`` configurations.
 
         a setting called ``foo``.
 
-       see also :cylc:setting:`[bar]pub` (this is a relative reference)
+        We can use relative references to link to other sections in the
+        same configuration tree. Just use ``..`` to back up a level
+        like this: :cylc:conf:`[..][bar]pub`
+
+        Note the ``[..]`` will disappear when the docs are built.
 
      .. cylc:section:: bar
 
@@ -84,12 +88,13 @@ Sphinx domain for ``cylc`` configurations.
 
               seconds as an integer.
 
-              the newer :cylc:value:`string` is preferred (this is also
+              the newer :cylc:value:`..=string` is preferred (this is also
               a relative reference).
 
            .. cylc:value:: string
 
               an iso8601 duration.
+
 
 Auto Documenters
 ----------------
@@ -101,28 +106,6 @@ Auto Documenters
    .. code-block:: rst
 
       .. auto-cylc-conf:: name-of-conf python.namespace.SPEC
-
-   For development the ``SPEC`` can alternatively be provided in JSON
-   format in the directive body.
-
-   .. rst-example::
-
-      .. auto-cylc-conf:: my-conf2.rc
-
-         {
-             "foo": {
-                 "bar": {
-                     "pub": ["V_BOOLEAN", "True"]
-                 },
-                 "baz": ["V_BOOLEAN", "True", "True", "False"]
-             }
-         }
-
-      Expected usage would look like this:
-
-      .. code-block:: rst
-
-         .. auto-cylc-conf:: suite cylc.flow.cfgspec.suite.SPEC
 
 .. rst:directive:: auto-cylc-type
 
@@ -158,6 +141,30 @@ Auto Documenters
             cylc.flow.parsec.validate.ParsecValidator.V_TYPE_HELP
             cylc.flow.parsec.validate.CylcConfigValidator.V_TYPE_HELP
 
+
+Directives
+----------
+
+.. rst:directive:: cylc-scope
+
+   Sets the context for cylc object references.
+
+   .. rst-example::
+
+      .. cylc-scope:: my-conf1.rc[bar]
+
+      Lets head to the :cylc:conf:`pub`.
+
+   .. rst-example::
+
+      Always be nice and reset the scope afterwards.
+
+      .. cylc-scope::
+
+      .. note::
+
+         This resets it to the hardcoded default which is ``suite.rc``.
+
 '''
 
 from cylc.sphinx_ext.cylc_lang.autodocumenters import (
@@ -166,7 +173,8 @@ from cylc.sphinx_ext.cylc_lang.autodocumenters import (
 )
 from cylc.sphinx_ext.cylc_lang.domains import (
     ParsecDomain,
-    CylcDomain
+    CylcDomain,
+    CylcScopeDirective
 )
 from cylc.sphinx_ext.cylc_lang.lexers import CylcLexer, CylcGraphLexer
 
@@ -190,4 +198,5 @@ def setup(app):
     app.add_domain(ParsecDomain)
     app.add_directive('auto-cylc-conf', CylcAutoDirective)
     app.add_directive('auto-cylc-type', CylcAutoTypeDirective)
+    app.add_directive('cylc-scope', CylcScopeDirective)
     return {'version': __version__, 'parallel_read_safe': True}

--- a/cylc/sphinx_ext/cylc_lang/__init__.py
+++ b/cylc/sphinx_ext/cylc_lang/__init__.py
@@ -164,7 +164,10 @@ from cylc.sphinx_ext.cylc_lang.autodocumenters import (
     CylcAutoDirective,
     CylcAutoTypeDirective
 )
-from cylc.sphinx_ext.cylc_lang.domains import CylcDomain
+from cylc.sphinx_ext.cylc_lang.domains import (
+    ParsecDomain,
+    CylcDomain
+)
 from cylc.sphinx_ext.cylc_lang.lexers import CylcLexer, CylcGraphLexer
 
 
@@ -184,6 +187,7 @@ def setup(app):
     app.add_lexer('cylc', CylcLexer())
     app.add_lexer('cylc-graph', CylcGraphLexer())
     app.add_domain(CylcDomain)
+    app.add_domain(ParsecDomain)
     app.add_directive('auto-cylc-conf', CylcAutoDirective)
     app.add_directive('auto-cylc-type', CylcAutoTypeDirective)
     return {'version': __version__, 'parallel_read_safe': True}

--- a/cylc/sphinx_ext/cylc_lang/autodocumenters.py
+++ b/cylc/sphinx_ext/cylc_lang/autodocumenters.py
@@ -9,17 +9,9 @@ from docutils.parsers.rst import Directive
 from docutils.statemachine import StringList
 
 from sphinx import addnodes
-from sphinx.directives import ObjectDescription
 
 from cylc.flow.parsec.config import ConfigNode
 from cylc.flow.parsec.validate import ParsecValidator, CylcConfigValidator
-from cylc.sphinx_ext.cylc_lang.domains import (
-    CylcConfDirective,
-    CylcSectionDirective,
-    CylcSettingDirective,
-    CylcValueDirective,
-    ParsecDirective
-)
 
 
 def get_vdr_info(vdr):
@@ -103,9 +95,9 @@ def directive(
     if content:
         ret.extend(
             indent(
-                # remove indentation and head,tail blanklines
+                # remove indentation and head,tail blanklines
                 dedent(content).strip(),
-                # add the directive indentation
+                # add the directive indentation
                 '   '
             ).splitlines()
         )
@@ -164,13 +156,13 @@ def doc_spec(spec):
                 doc_conf(item)
             )
         elif item.is_leaf():
-            # setting
+            # setting
             ret.extend([
                 indent(line, '   ' * level)
                 for line in doc_setting(item)
             ])
         else:
-            # section
+            # section
             ret.extend([
                 indent(line, '   ' * level)
                 for line in doc_section(item)
@@ -209,9 +201,8 @@ class CylcAutoDirective(Directive):
     optional_arguments = 1
 
     def run(self):
-        conf_name = self.arguments[0].strip()
         if len(self.arguments) == 2:
-            spec = get_obj_from_module(self.arguments[1].strip())
+            spec = get_obj_from_module(self.arguments[0].strip())
         else:
             spec = json.loads('\n'.join(self.content))
 

--- a/cylc/sphinx_ext/cylc_lang/autodocumenters.py
+++ b/cylc/sphinx_ext/cylc_lang/autodocumenters.py
@@ -133,6 +133,8 @@ def doc_setting(item):
     if item.options:
         fields['options'] = ', '.join(
             f'``{option}``'
+            if option != ''
+            else '`` ``'  # prevents ```` which is an RST error
             for option in item.options
         )
 

--- a/cylc/sphinx_ext/cylc_lang/autodocumenters.py
+++ b/cylc/sphinx_ext/cylc_lang/autodocumenters.py
@@ -11,6 +11,7 @@ from docutils.statemachine import StringList
 from sphinx import addnodes
 from sphinx.directives import ObjectDescription
 
+from cylc.flow.parsec.config import ConfigNode
 from cylc.flow.parsec.validate import ParsecValidator, CylcConfigValidator
 from cylc.sphinx_ext.cylc_lang.domains import (
     CylcConfDirective,
@@ -118,7 +119,7 @@ def doc_setting(item):
     if item.vdr:
         vdr_info = get_vdr_info(item.vdr)
         fields['type'] = f':parsec:type:`{vdr_info[0]}`'
-    if item.default:
+    if item.default and item.default != ConfigNode.UNSET:
         fields['default'] = f'``{item.default}``'
     if item.options:
         fields['options'] = ', '.join(

--- a/cylc/sphinx_ext/cylc_lang/autodocumenters.py
+++ b/cylc/sphinx_ext/cylc_lang/autodocumenters.py
@@ -128,7 +128,7 @@ def doc_setting(item):
 
     return directive(
         'cylc:setting',
-        [item.name],
+        [item.display_name],
         {},
         fields,
         item.desc
@@ -138,7 +138,7 @@ def doc_setting(item):
 def doc_section(item):
     return directive(
         'cylc:section',
-        [item.name],
+        [item.display_name],
         {},
         {},
         item.desc

--- a/cylc/sphinx_ext/cylc_lang/autodocumenters.py
+++ b/cylc/sphinx_ext/cylc_lang/autodocumenters.py
@@ -109,10 +109,10 @@ def directive(
 def repr_value(value):
     """Return a string repr for a configuration value.
 
-        >>> doc_default([1, 2, 3])
+        >>> repr_value([1, 2, 3])
         '1, 2, 3'
 
-        >>> doc_default(['a b', 'c d'])
+        >>> repr_value(['a b', 'c d'])
         "'a b', 'c d'"
     """
     if isinstance(value, list):

--- a/cylc/sphinx_ext/cylc_lang/autodocumenters.py
+++ b/cylc/sphinx_ext/cylc_lang/autodocumenters.py
@@ -109,17 +109,30 @@ def directive(
 def repr_value(value):
     """Return a string repr for a configuration value.
 
-        >>> repr_value([1, 2, 3])
-        '1, 2, 3'
-
+    Examples:
+        >>> repr_value([1, 3, 5])
+        '1, 3, 5'
         >>> repr_value(['a b', 'c d'])
         "'a b', 'c d'"
+        >>> repr_value([1, 2, 3])
+        '1 .. 3'
+
     """
     if isinstance(value, list):
+        if (
+                all((isinstance(x, int) for x in value))
+                and value == list(range(value[0], value[-1] + 1))
+        ):
+            # format range lists nicely (e.g. port ranges)
+            return f'{value[0]} .. {value[-1]}'
+
+        # format regular lists being careful to quote where necessary
         return ', '.join((
             f"'{x}'" if ' ' in str(x) else f'{x}'
             for x in value
         ))
+
+    # otherwise just use the string representation
     return str(value)
 
 

--- a/cylc/sphinx_ext/cylc_lang/autodocumenters.py
+++ b/cylc/sphinx_ext/cylc_lang/autodocumenters.py
@@ -106,13 +106,30 @@ def directive(
     return ret
 
 
+def repr_value(value):
+    """Return a string repr for a configuration value.
+
+        >>> doc_default([1, 2, 3])
+        '1, 2, 3'
+
+        >>> doc_default(['a b', 'c d'])
+        "'a b', 'c d'"
+    """
+    if isinstance(value, list):
+        return ', '.join((
+            f"'{x}'" if ' ' in str(x) else f'{x}'
+            for x in value
+        ))
+    return str(value)
+
+
 def doc_setting(item):
     fields = {}
     if item.vdr:
         vdr_info = get_vdr_info(item.vdr)
         fields['type'] = f':parsec:type:`{vdr_info[0]}`'
     if item.default and item.default != ConfigNode.UNSET:
-        fields['default'] = f'``{item.default}``'
+        fields['default'] = f'``{repr_value(item.default)}``'
     if item.options:
         fields['options'] = ', '.join(
             f'``{option}``'
@@ -201,7 +218,7 @@ class CylcAutoDirective(Directive):
     optional_arguments = 1
 
     def run(self):
-        if len(self.arguments) == 2:
+        if len(self.arguments) == 1:
             spec = get_obj_from_module(self.arguments[0].strip())
         else:
             spec = json.loads('\n'.join(self.content))

--- a/cylc/sphinx_ext/cylc_lang/domains.py
+++ b/cylc/sphinx_ext/cylc_lang/domains.py
@@ -16,10 +16,12 @@ KEYS = {
     'value': lambda s: f'={s}'
 }
 
+# NOTE we allow `<...>` because this is used for custom sections
+# (i.e. for `__MANY__` items)
 CYLC_WORD = r'''
-    (?:[\w\-\_])?
+    (?:[\<\w\-\_])?
     (?:[\w\-\_][\w\-\_ \.]+)?
-    [\w]
+    [\w\>]
 '''
 
 REGEX = re.compile(

--- a/cylc/sphinx_ext/cylc_lang/domains.py
+++ b/cylc/sphinx_ext/cylc_lang/domains.py
@@ -41,6 +41,7 @@ REGEX = re.compile(
             (?:\[(?P<section1>{CYLC_WORD})\])?
             (?:\[(?P<section2>{CYLC_WORD})\])?
             (?:\[(?P<section3>{CYLC_WORD})\])?
+            (?:\[(?P<section4>{CYLC_WORD})\])?
         )|(?:
             \|
         )

--- a/cylc/sphinx_ext/cylc_lang/domains.py
+++ b/cylc/sphinx_ext/cylc_lang/domains.py
@@ -299,7 +299,6 @@ class CylcDirective(ObjectDescription):
 
     def handle_signature(self, sig, signode):
         sig, value = self.sanitise_signature(sig)
-        # signode += addnodes.desc_name(sig, sig)
         signode += addnodes.desc_name(sig, self.display_name())
         if value:
             annotation = f' = {value}'

--- a/cylc/sphinx_ext/cylc_lang/domains.py
+++ b/cylc/sphinx_ext/cylc_lang/domains.py
@@ -584,7 +584,6 @@ class CylcDomain(Domain):
             )
             import sys
             print(message, sys.stderr)
-            # breakpoint()
             return None
 
         # standardise the display text

--- a/cylc/sphinx_ext/cylc_lang/domains.py
+++ b/cylc/sphinx_ext/cylc_lang/domains.py
@@ -467,7 +467,11 @@ class CylcDomain(Domain):
         # get tokens for the object we are trying to reference
         tokens = tokenise(target)
 
-        # check if we have a relative reference
+        if not tokens['conf']:
+            # TODO: allow setting relative from anywhere with context cmd
+            tokens['conf'] = 'suite.rc'
+
+        # check if we have a relative reference from a definition
         if len([key for key, value in tokens.items() if value]) < 2:
             if typ == 'section':
                 tokens = {typ: (target,)}

--- a/cylc/sphinx_ext/cylc_lang/domains.py
+++ b/cylc/sphinx_ext/cylc_lang/domains.py
@@ -115,12 +115,17 @@ def tokenise(namespace_string):
 def detokenise(namespace_tokens):
     """
     Examples:
+        Full namespace
         >>> detokenise(tokenise('x[a][b][c]d=e'))
         'x[a][b][c]d=e'
         >>> detokenise(tokenise('x|a'))
         'x|a'
         >>> detokenise(tokenise('a'))
         'a'
+
+        Partial namespace
+        >>> detokenise({'section': 'a'})
+        '[a]'
 
     """
     ret = ''
@@ -262,10 +267,6 @@ class CylcDirective(ObjectDescription):
 
         index_node, cont_node = ObjectDescription.run(self)
 
-        # cont_node.ref_context = {
-        #     self.ref_context_key: None
-        # }
-
         return [index_node, cont_node]
 
     def before_content(self):
@@ -298,11 +299,18 @@ class CylcDirective(ObjectDescription):
 
     def handle_signature(self, sig, signode):
         sig, value = self.sanitise_signature(sig)
-        signode += addnodes.desc_name(sig, sig)
+        # signode += addnodes.desc_name(sig, sig)
+        signode += addnodes.desc_name(sig, self.display_name())
         if value:
             annotation = f' = {value}'
             signode += addnodes.desc_annotation(annotation, annotation)
         return (sig, self.NAME, sig)
+
+    def display_name(self):
+        sig = self.arguments[0]
+        if self.NAME == CylcSectionDirective.NAME:
+            sig = [sig]
+        return detokenise({self.NAME: sig})
 
     def get_tokens(self, sig):
         return tokens_from_partials(

--- a/cylc/sphinx_ext/cylc_lang/domains.py
+++ b/cylc/sphinx_ext/cylc_lang/domains.py
@@ -461,6 +461,10 @@ class CylcDomain(Domain):
     def resolve_xref(
         self, env, fromdocname, builder, typ, target, node, contnode
     ):
+        # remove the value from a reference if present
+        target, *_ = target.rsplit('=', 1)
+        target = target.strip()
+
         # strip intersphinx mapping
         # TODO
 

--- a/cylc/sphinx_ext/cylc_lang/tests/test_autodocumenters.py
+++ b/cylc/sphinx_ext/cylc_lang/tests/test_autodocumenters.py
@@ -1,0 +1,293 @@
+import pytest
+
+from cylc.flow.parsec.config import ConfigNode
+from cylc.flow.parsec.validate import ParsecValidator as VDR
+
+from cylc.sphinx_ext.cylc_lang.autodocumenters import (
+    directive,
+    doc_conf,
+    doc_section,
+    doc_setting,
+    doc_spec,
+    doc_type
+)
+
+
+def test_directive():
+    """It should return RST directives."""
+    assert directive(
+        'directive-name',
+        ['arg1', 'arg2', 'arg3'],
+        {'opt1': 'foo', 'opt2': 'bar'},
+        {'field1': 'baz', 'field2': 'pub'},
+        '''
+            foo
+            bar
+            baz
+        '''
+    ) == [
+        '.. directive-name:: arg1 arg2 arg3',
+        '   :opt1: foo',
+        '   :opt2: bar',
+        '',
+        '   :field1: baz',
+        '   :field2: pub',
+        '',
+        '   foo',
+        '   bar',
+        '   baz',
+        ''
+    ]
+
+    # nothing
+    assert directive(
+        'directive-name',
+        [], {}, {}, ''
+    ) == [
+        '.. directive-name::',
+        ''
+    ]
+
+    # no args
+    assert directive(
+        'directive-name',
+        [],
+        {'opt1': 'foo'},
+        {'field1': 'baz'},
+        'content'
+    ) == [
+        '.. directive-name::',
+        '   :opt1: foo',
+        '',
+        '   :field1: baz',
+        '',
+        '   content',
+        ''
+    ]
+
+    # no opts
+    assert directive(
+        'directive-name',
+        ['arg1'],
+        {},
+        {'field1': 'baz'},
+        'content'
+    ) == [
+        '.. directive-name:: arg1',
+        '',
+        '   :field1: baz',
+        '',
+        '   content',
+        ''
+    ]
+
+    # no fields
+    assert directive(
+        'directive-name',
+        ['arg1', 'arg2', 'arg3'],
+        {'opt1': 'foo'},
+        {},
+        'content'
+    ) == [
+        '.. directive-name:: arg1 arg2 arg3',
+        '   :opt1: foo',
+        '',
+        '   content',
+        ''
+    ]
+
+    # no content
+    assert directive(
+        'directive-name',
+        ['arg1', 'arg2', 'arg3'],
+        {'opt1': 'foo'},
+        {},
+        ''
+    ) == [
+        '.. directive-name:: arg1 arg2 arg3',
+        '   :opt1: foo',
+        ''
+    ]
+
+@pytest.fixture
+def simple_setting():
+    """A leaf-node configuration."""
+    return ConfigNode('simple-setting', VDR.V_STRING)
+
+
+@pytest.fixture
+def option_setting():
+    """A leaf-node configuration with options."""
+    return ConfigNode('option-setting', VDR.V_STRING, options=['a', 'b', 'c'])
+
+
+@pytest.fixture
+def default_setting():
+    """A leaf-node configuration with a default."""
+    return ConfigNode('default-setting', VDR.V_STRING, default='x')
+
+@pytest.fixture
+def documented_setting():
+    """A leaf-node configuration with documentation."""
+    return ConfigNode('documented-setting', VDR.V_STRING, desc='''
+        foo
+        bar
+        baz
+    ''')
+
+
+def test_doc_setting(
+        simple_setting,
+        option_setting,
+        default_setting,
+        documented_setting
+):
+    """It should document leaf-node configurations."""
+    assert doc_setting(simple_setting) == [
+        '.. cylc:setting:: simple-setting',
+        '',
+        '   :type: :parsec:type:`string`',
+        ''
+    ]
+
+    assert doc_setting(option_setting) == [
+        '.. cylc:setting:: option-setting',
+        '',
+        '   :type: :parsec:type:`string`',
+        '   :options: ``a``, ``b``, ``c``',
+        ''
+    ]
+
+    assert doc_setting(default_setting) == [
+        '.. cylc:setting:: default-setting',
+        '',
+        '   :type: :parsec:type:`string`',
+        '   :default: ``x``',
+        ''
+    ]
+
+    assert doc_setting(documented_setting) == [
+        '.. cylc:setting:: documented-setting',
+        '',
+        '   :type: :parsec:type:`string`',
+        '',
+        '   foo',
+        '   bar',
+        '   baz',
+        ''
+    ]
+
+
+@pytest.fixture
+def simple_section():
+    """A configuration section."""
+    return ConfigNode('simple-section')
+
+
+def test_doc_section(simple_section):
+    """It should docuement configuration sections."""
+    assert doc_section(simple_section) == [
+        '.. cylc:section:: simple-section',
+        ''
+    ]
+
+
+@pytest.fixture
+def simple_conf():
+    """A root configuration."""
+    return ConfigNode('simple-conf')
+
+
+@pytest.fixture
+def documented_conf():
+    """A root configuration with documentation."""
+    return ConfigNode('documented-conf', desc='''
+        foo
+        bar
+        baz
+    ''')
+
+
+def test_doc_conf(simple_conf, documented_conf):
+    """It should document top-level configuration items."""
+    assert doc_conf(simple_conf) == [
+        '.. cylc:conf:: simple-conf',
+        ''
+    ]
+
+    assert doc_conf(documented_conf) == [
+        '.. cylc:conf:: documented-conf',
+        '',
+        '   foo',
+        '   bar',
+        '   baz',
+        ''
+    ]
+
+
+@pytest.fixture
+def documented_spec():
+    """A configuration tree with documentation."""
+    with ConfigNode('documented-conf', desc='a\nb\nc') as spec:
+        with ConfigNode('documented-section', desc='d\ne'):
+            ConfigNode('documented-setting', VDR.V_STRING, desc='f\ng')
+    return spec
+
+
+def test_doc_spec(documented_spec):
+    """It should document entire configuration trees."""
+    assert doc_spec(documented_spec) == [
+        '.. cylc:conf:: documented-conf',
+        '',
+        '   a',
+        '   b',
+        '   c',
+        '',
+        '   .. cylc:section:: documented-section',
+        '',
+        '      d',
+        '      e',
+        '',
+        '      .. cylc:setting:: documented-setting',
+        '',
+        '         :type: :parsec:type:`string`',
+        '',
+        '         f',
+        '         g',
+        ''
+    ]
+
+
+@pytest.fixture
+def basic_parsec_type():
+    return {
+        'name': 'type name',
+        'help': '''
+            help
+            string
+        ''',
+        'examples': ['a', 'b', 'c'],
+        'references': [('foo', 'FOO'), ('bar', 'BAR')]
+    }
+
+
+def test_doc_type(basic_parsec_type):
+    assert doc_type(basic_parsec_type) == [
+        '.. parsec:type:: type name',
+        '',
+        '   help',
+        '   string',
+        '',
+        '   .. rubric:: Examples:',
+        '',
+        '   * ``a``',
+        '   * ``b``',
+        '   * ``c``',
+        '',
+        '   .. rubric:: See Also:',
+        '',
+        '   * :foo:`FOO`',
+        '   * :bar:`BAR`',
+        '',
+
+    ]

--- a/cylc/sphinx_ext/cylc_lang/tests/test_autodocumenters.py
+++ b/cylc/sphinx_ext/cylc_lang/tests/test_autodocumenters.py
@@ -109,6 +109,7 @@ def test_directive():
         ''
     ]
 
+
 @pytest.fixture
 def simple_setting():
     """A leaf-node configuration."""
@@ -125,6 +126,7 @@ def option_setting():
 def default_setting():
     """A leaf-node configuration with a default."""
     return ConfigNode('default-setting', VDR.V_STRING, default='x')
+
 
 @pytest.fixture
 def documented_setting():


### PR DESCRIPTION
Sibling PRs:

* https://github.com/cylc/cylc-flow/pull/3559
* https://github.com/cylc/cylc-doc/pull/121

Highlights:

* Autodocument Cylc/Parsec configurations from the new `ConfigNode` tree thing.
* Add a powerful relative referencing syntax.

Examples:

```rst
This feature is configured using the options in :cylc:conf:`file.rc[foo][bar][baz]`:

.. cylc-scope: file.rc[foo][bar][baz]

(no need to specify the full path in this section because we have set the scope)

* :cylc:conf:`pub` - does something
* :cylc:conf:`aux` - does something else
* :cylc:conf:`foot` - and now for something completely different

.. cylc:scope::

(but we do have to remember to reset the scope afterwards)
```

Documentation:

All [auto-]documented in the `cylc_lang` extension, try building the docs 😀.