### PR TITLE
pin gh-pages deployment action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           make html
       - name: deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@286809f  # v3.5.8
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./_build/html


### PR DESCRIPTION
Documentation suggests pinning actions against tags. Unfortunately tags are volatile which presents a security issue. Commits, at-lest, are immutable.