### PR TITLE
pin Sphinx version for hieroglyph compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     description='Sphinx extensions for documenting Cylc',
     long_description=open('README.rst', 'r').read(),
     install_requires=[
-        'sphinx>=2.1.0',
+        'sphinx>=2.1.0,<2.4.0',
         # TODO: docutils version is pinned due to issue with hieroglyph
         'docutils<0.16.0'
     ],


### PR DESCRIPTION
Workaround until we have a new Hieroglyph release or find a new slide builder.