### PR TITLE
actions: release(publish->create)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: release
 
-on: [publish]
+on: [create]
 
 jobs:
   gh-pages:


### PR DESCRIPTION
Prepare for the upcoming 1.0.1 release.

Using `create` rather than `release` as there is no really benefit of GH releases for repos like this.

The `publish` tag now has arguments? Curiously this action has run in the past (we didn't do a manual docs deploy).

One review should be sufficient.