### PR TITLE
cylc_lang: handle inheritance in configuration documentation

### DIFF
--- a/cylc/sphinx_ext/cylc_lang/autodocumenters.py
+++ b/cylc/sphinx_ext/cylc_lang/autodocumenters.py
@@ -161,11 +161,14 @@ def doc_setting(item):
 
 
 def doc_section(item):
+    fields = {}
+    if item.meta:
+        fields['Inherits'] = f':cylc:conf:`{repr(item.meta)}`'
     return directive(
         'cylc:section',
         [item.display_name],
         {},
-        {},
+        fields,
         item.desc
     )
 
@@ -187,13 +190,13 @@ def doc_spec(spec):
             ret.extend(
                 doc_conf(item)
             )
-        elif item.is_leaf():
+        elif item.is_leaf() and not item.meta:
             # setting
             ret.extend([
                 indent(line, '   ' * level)
                 for line in doc_setting(item)
             ])
-        else:
+        elif not item.is_leaf():
             # section
             ret.extend([
                 indent(line, '   ' * level)


### PR DESCRIPTION
Companion to https://github.com/cylc/cylc-flow/pull/3630/files#diff-19e07f30da29f82a9e78c95b6f04670bL197-R200

* Document if a configuration inherits from another section.
* Don't document inherited settings.