### PR TITLE
cylc lang: permit arbitrary whitespace

### DIFF
--- a/cylc/sphinx_ext/cylc_lang/__init__.py
+++ b/cylc/sphinx_ext/cylc_lang/__init__.py
@@ -74,6 +74,11 @@ Sphinx domain for ``cylc`` configurations.
 
         Note the ``[..]`` will disappear when the docs are built.
 
+        Note also that arbitrary whitespace is supported in references,
+        for example :cylc:conf:`[..]
+        [bar]
+        pub`
+
      .. cylc:section:: bar
 
         a section called ``bar``.


### PR DESCRIPTION
Permit arbitrary whitespace in the Cylc Domain e.g:

```rst
See the :cylc:conf:`flow.cylc
[scheduling]` section.
```

This isn't an issue with the Cylc Domain, other Sphinx domains will treat arbitrary whitespace as an error, however, in the Cylc domain namespaces can be quite long which can cause issues with line length.