### PR TITLE
Allow slash in config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ below.
  - Oliver Sanders
  - Tim Pillinger
  - Bruno Kinoshita
+ - Mel Hall
 
 (All contributors are identifiable with email addresses in the git version
 control logs or otherwise.)

--- a/cylc/sphinx_ext/cylc_lang/__init__.py
+++ b/cylc/sphinx_ext/cylc_lang/__init__.py
@@ -66,7 +66,7 @@ Sphinx domain for ``cylc`` configurations.
 
      .. cylc:setting:: foo
 
-        a setting called ``foo``.
+        A setting called ``foo``.
 
         We can use relative references to link to other sections in the
         same configuration tree. Just use ``..`` to back up a level
@@ -81,14 +81,14 @@ Sphinx domain for ``cylc`` configurations.
 
      .. cylc:section:: bar
 
-        a section called ``bar``.
+        A section called ``bar``.
 
         Here's a link to :cylc:conf:`this section <my-conf1.cylc[bar]>`, note
         we re-named the target using the sphinx/rst ``name <target>`` syntax.
 
         .. cylc:setting:: pub
 
-           a setting called ``pub``
+           A setting called ``pub``
 
            .. cylc:value:: integer
 
@@ -102,6 +102,10 @@ Sphinx domain for ``cylc`` configurations.
            .. cylc:value:: string
 
               an iso8601 duration.
+
+        .. cylc:setting:: a/b/c
+
+           A setting with a ``/`` in the name.
 
 
 Auto Documenters

--- a/cylc/sphinx_ext/cylc_lang/domains.py
+++ b/cylc/sphinx_ext/cylc_lang/domains.py
@@ -328,6 +328,8 @@ class CylcDirective(ObjectDescription):
         Examples:
             >>> CylcSettingDirective.sanitise_signature('a=b')
             ('a', 'b')
+            >>> CylcSettingDirective.sanitise_signature('share/cycle')
+            ('share/cycle', None)
 
         """
         value = None

--- a/cylc/sphinx_ext/cylc_lang/domains.py
+++ b/cylc/sphinx_ext/cylc_lang/domains.py
@@ -344,8 +344,8 @@ class CylcDirective(ObjectDescription):
             value = tokens['value']
             tokens['value'] = None
             sig = detokenise(tokens)
-            if is_slash_in_sig is True:
-                sig = sig.replace('FORWARD_SLASH', '/')
+        if is_slash_in_sig is True:
+            sig = sig.replace('FORWARD_SLASH', '/')
         return sig, value
 
     def handle_signature(self, sig, signode):

--- a/cylc/sphinx_ext/cylc_lang/domains.py
+++ b/cylc/sphinx_ext/cylc_lang/domains.py
@@ -331,11 +331,19 @@ class CylcDirective(ObjectDescription):
 
         """
         value = None
+        is_slash_in_sig = False
+        # This is necessary to allow slash config entries, e.g. share/cycle
+        if "/" in sig:
+            is_slash_in_sig = True
+            sig = sig.replace('/', 'FORWARD_SLASH')
+
         if cls.NAME == 'setting':
             tokens = tokenise(sig)
             value = tokens['value']
             tokens['value'] = None
             sig = detokenise(tokens)
+            if is_slash_in_sig is True:
+                sig = sig.replace('FORWARD_SLASH', '/')
         return sig, value
 
     def handle_signature(self, sig, signode):

--- a/cylc/sphinx_ext/cylc_lang/domains.py
+++ b/cylc/sphinx_ext/cylc_lang/domains.py
@@ -20,8 +20,8 @@ KEYS = {
 # NOTE we allow `<...>` because this is used for custom sections
 # (i.e. for `__MANY__` items)
 CYLC_WORD = r'''
-    (?:[\<\w\-\_])?
-    (?:[\w\-\_][\w\-\_ ]+)?
+    (?:[\<\w\-\_\/])?
+    (?:[\w\-\_][\w\-\_\/ ]+)?
     [\w\>]
 '''
 
@@ -328,24 +328,13 @@ class CylcDirective(ObjectDescription):
         Examples:
             >>> CylcSettingDirective.sanitise_signature('a=b')
             ('a', 'b')
-            >>> CylcSettingDirective.sanitise_signature('share/cycle')
-            ('share/cycle', None)
-
         """
         value = None
-        is_slash_in_sig = False
-        # This is necessary to allow slash config entries, e.g. share/cycle
-        if "/" in sig:
-            is_slash_in_sig = True
-            sig = sig.replace('/', 'FORWARD_SLASH')
-
         if cls.NAME == 'setting':
             tokens = tokenise(sig)
             value = tokens['value']
             tokens['value'] = None
             sig = detokenise(tokens)
-        if is_slash_in_sig is True:
-            sig = sig.replace('FORWARD_SLASH', '/')
         return sig, value
 
     def handle_signature(self, sig, signode):


### PR DESCRIPTION
This PR is a possible solution to the issue identified in [Symlink Dirs PR](https://github.com/cylc/cylc-flow/pull/3884), where, adding config item `share/cycle` to enable users to configure this directory for symlinking, resulted in an error when building the docs. This was because the `/`  is a special character. 

I have built the docs (with the https://github.com/cylc/cylc-flow/pull/3884) - checking that the share/cycle no longer results in a doc build fail. 