### PR TITLE
Prepare 1.3.0 with GH Actions workflow fix

### DIFF
--- a/.github/workflows/2_auto_publish_release.yml
+++ b/.github/workflows/2_auto_publish_release.yml
@@ -20,9 +20,6 @@ jobs:
     timeout-minutes: 10
     steps:
 
-    - name: Get the version number
-      uses: cylc/release-actions/stage-2/get-version-from-pr@v1
-
     - name: Checkout repo
       uses: actions/checkout@v2
       with:
@@ -38,6 +35,9 @@ jobs:
         sudo apt-get install -y graphviz
         pip install git+https://github.com/cylc/cylc-flow/  # install latest cylc-flow
         pip install -e .[all]
+
+    - name: Get the version number
+      uses: cylc/release-actions/stage-2/get-version-from-pr@v1
 
     - name: Build
       uses: cylc/release-actions/build-python-package@v1


### PR DESCRIPTION
#40 failed. Hopefully by using this branch and adding the release label, merging this should retrigger the 2nd stage of the release process.