### PR TITLE
Fix large code-block captions

### DIFF
--- a/cylc/sphinx_ext/hieroglyph_addons/__init__.py
+++ b/cylc/sphinx_ext/hieroglyph_addons/__init__.py
@@ -1,16 +1,16 @@
 """Patches the hard-coded Heroglyph slides theme.
 
-.. _Heroglyph: https://github.com/nyergler/hieroglyph
+.. _Hieroglyph: https://github.com/nyergler/hieroglyph
 
 .. warning::
 
-   These modifications only in `Heroglyph`_ slides builds.
+   These modifications only work in `Hieroglyph`_ slides builds.
 
 .. nextslide::
 
 .. note::
 
-   extension is automatically loaded when added to extensions, no directives or
+   Extension is automatically loaded when added to extensions, no directives or
    configurations required.
 
 .. nextslide::

--- a/cylc/sphinx_ext/hieroglyph_addons/_static/css/hieroglyph_theme_addons.css
+++ b/cylc/sphinx_ext/hieroglyph_addons/_static/css/hieroglyph_theme_addons.css
@@ -1,38 +1,38 @@
 /* (1)
  * Make quotations small enough to fit on the slide. */
-q {
+.slide q {
     font-size: 1em;
 }
 
 
 /* (2)
  * Add a bit of space between slide titles and images. */
-object, img {
+.slide object, .slide img {
     margin: 1em 0 1em 0;
 }
 
 
 /* (3)
  * Don't display glossary terms as hyperlinks. */
-a.reference {
+.slide a.reference {
     text-decoration: none
 }
-a.reference span.std {
-    text-decoration: underline;   
+.slide a.reference span.std {
+    text-decoration: underline;
 }
-a.reference span.xref {
+.slide a.reference span.xref {
     text-decoration: none;
     color: #909090;
     font-style: italic;
 }
-a.reference span.xref:hover {
-    text-decoration: underline;   
+.slide a.reference span.xref:hover {
+    text-decoration: underline;
     color: #0066CC;
 }
 
 
 /* (4)
  * Make code block captions legible. */
-.code-block-caption span {
+.slide .code-block-caption span {
     font-size: 2em;
 }

--- a/cylc/sphinx_ext/rtd_theme_addons/__init__.py
+++ b/cylc/sphinx_ext/rtd_theme_addons/__init__.py
@@ -8,7 +8,7 @@
 
 .. note::
 
-   extension is automatically loaded when added to extensions, no directives or
+   Extension is automatically loaded when added to extensions, no directives or
    configurations required.
 
 
@@ -25,7 +25,7 @@ Modifications:
 
 2. Permit linking admonitions
 
-   .. note::
+   .. admonition:: Example
 
       When hovering the title of this admonition a link symbol should appear.
 
@@ -43,7 +43,19 @@ Modifications:
 
 5. Restyle code-block captions
 
+   .. code-block:: bash
+      :caption: Hello World
+
+      $ echo 'hello world'
+
 6. Address lack of whitespace under lists in admonitions
+
+   .. admonition:: Example
+
+      - Darmok
+      - Jalad
+
+      Temba, his arms wide.
 
 7. Improve sidebar scrolling
 

--- a/cylc/sphinx_ext/rtd_theme_addons/_static/css/addons.css
+++ b/cylc/sphinx_ext/rtd_theme_addons/_static/css/addons.css
@@ -98,10 +98,13 @@ span.versionmodified{
 
 
 /* (5)
- * Place code-block captions in italics. */
+ * Restyle code-block captions. */
 .code-block-caption {
     font-style: italic;
     color: #808080;
+}
+.code-block-caption span {
+    font-size: 1.2em;
 }
 
 


### PR DESCRIPTION
These changes close https://github.com/cylc/cylc-doc/issues/210

The CSS for making code-block captions larger in Hieroglyph slides was being applied to the HTML build too, for some reason. Without addressing why, easy fix is to prepend `.slide ` to each CSS rule in the Hieroglyph addons.

<img src="https://user-images.githubusercontent.com/61982285/130629278-485334ee-8c9b-4e3d-bdae-f2f323ef878e.png" width="750">


Also add a couple of examples for ReadTheDocs theme addons