### PR TITLE
literal_sub_include: a literalinclude directive with substitution support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,30 +12,34 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v1
+
+      - name: eslint
+        run: npx eslint .
+
       - name: configure python
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: configure node
-        uses: actions/setup-node@v1
-        with:
-            node-version: '10.x'
+
       - name: install
         run: |
           sudo apt-get install -y graphviz
           pip install git+https://github.com/cylc/cylc-flow/  # install latest cylc-flow
           pip install -e .[all]
-          npm install -g eslint
-      - name: style
+
+      - name: pycodestyle
         run: |
           pycodestyle .
-          eslint cylc/
+          npx eslint cylc/
+
       - name: unittest
         run: |
           pytest
+
       - name: build
         run: |
           make html slides linkcheck
+
       - name: debug
         if: failure()
         run: |

--- a/conf.py
+++ b/conf.py
@@ -39,6 +39,7 @@ extensions = [
     'cylc.sphinx_ext.rtd_theme_addons',
     'cylc.sphinx_ext.rst_example',
     'cylc.sphinx_ext.sub_lang',
+    'cylc.sphinx_ext.literal_sub_include',
 
     # addons required by extensions
     'hieroglyph',
@@ -61,3 +62,8 @@ intersphinx_mapping = {
 
 # avoid issues with transitive files
 exclude_patterns = ['_build', 'venv', 'env']
+
+# for use by the literal_sub_include plugin
+literal_sub_include_subs = {
+    'version': __version__,
+}

--- a/cylc/sphinx_ext/literal_sub_include/__init__.py
+++ b/cylc/sphinx_ext/literal_sub_include/__init__.py
@@ -1,0 +1,70 @@
+# -----------------------------------------------------------------------------
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+"""A literal include block that supports hardcoded substitutions.
+
+.. note::
+
+   Hopefully we can move a feature like this into Sphinx in the long run.
+
+
+Directives
+----------
+
+.. rst:directive:: literalsubinclude
+
+   Directive for practical exercise.
+
+   .. rst-example::
+
+      With substitutions turned off:
+
+      .. literalsubinclude:: ../cylc/sphinx_ext/literal_sub_include/test.txt
+
+      With substitutions turned on:
+
+      .. literalsubinclude:: ../cylc/sphinx_ext/literal_sub_include/test.txt
+        :substitutions:
+
+Configurations
+--------------
+
+
+.. object:: literal_sub_include_subs
+
+   Dictionary containing key value pairs of substitutions e.g::
+
+      literal_sub_include_subs = {
+          'version': '123',
+      }
+
+.. note::
+
+   Patching into the Sphinx substitutions appears to be tricky due to the
+   stage at which they are applied.
+
+"""
+
+from cylc.sphinx_ext.literal_sub_include.directives import LiteralSubInclude
+
+__version__ = '1.0.0'
+
+
+def setup(app: "Sphinx"):
+    app.add_directive('literalsubinclude', LiteralSubInclude)
+    app.add_config_value('literal_sub_include_subs', {}, 'env', 'dict')
+    return {'version': __version__, 'parallel_read_safe': True}

--- a/cylc/sphinx_ext/literal_sub_include/directives.py
+++ b/cylc/sphinx_ext/literal_sub_include/directives.py
@@ -1,0 +1,71 @@
+# -----------------------------------------------------------------------------
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+from functools import wraps
+
+from docutils.parsers.rst import directives
+from sphinx.directives.code import LiteralInclude, LiteralIncludeReader
+
+
+def substitute(lines, items):
+    """Substitute |strings| in the provided "lines" with values from "items".
+
+    Example:
+        >>> lines = ['foo |bar| baz']
+        >>> substitute(lines, {'bar': 'pub'})
+        >>> lines
+        ['foo pub baz']
+    """
+    for ind, line in enumerate(lines):
+        for key, value in items.items():
+            lines[ind] = line.replace(f'|{key}|', value)
+
+
+def substitution_decorator(fcn):
+    """Decorator for LiteralIncludeReader adding substitution functionality."""
+    @wraps(fcn)
+    def _inner(self, *args, **kwargs):
+        nonlocal fcn
+        lines = fcn(self, *args, **kwargs)
+        if 'substitutions' in self.options:
+            # perform substitutions
+            substitute(
+                lines,
+                self.options['_config'].literal_sub_include_subs,
+            )
+        return lines
+    return _inner
+
+
+# patch the LiteralIncludeReader class
+LiteralIncludeReader.read_file = substitution_decorator(
+    LiteralIncludeReader.read_file
+)
+
+
+class LiteralSubInclude(LiteralInclude):
+    # add an option to turn on subs
+    option_spec = {
+        **LiteralInclude.option_spec,
+        'substitutions': directives.flag,
+    }
+
+    def run(self):
+        # pass the config through to the LiteralIncludeReader
+        self.options['_config'] = self.config
+        return LiteralInclude.run(self)

--- a/cylc/sphinx_ext/literal_sub_include/test.txt
+++ b/cylc/sphinx_ext/literal_sub_include/test.txt
@@ -1,0 +1,1 @@
+cylc-sphinx-extensions version |version|

--- a/index.rst
+++ b/index.rst
@@ -11,8 +11,9 @@ Available Extensions
    cylc.sphinx_ext.diff_selection
    cylc.sphinx_ext.grid_table
    cylc.sphinx_ext.hieroglyph_addons
+   cylc.sphinx_ext.literal_sub_include
    cylc.sphinx_ext.minicylc
    cylc.sphinx_ext.practical
-   cylc.sphinx_ext.rtd_theme_addons
    cylc.sphinx_ext.rst_example
+   cylc.sphinx_ext.rtd_theme_addons
    cylc.sphinx_ext.sub_lang


### PR DESCRIPTION
A small (hopefully short lived) extension to the `.. literalinclude::` directive to allow us to template the cylc version into environment files for documentation / testing.