### PR TITLE
cylc_lang: fix for cylc 8 graph setting format

### DIFF
--- a/cylc/sphinx_ext/cylc_lang/__init__.py
+++ b/cylc/sphinx_ext/cylc_lang/__init__.py
@@ -32,12 +32,16 @@ Lexer for the Cylc language and ``flow.cylc`` extensions.
 
       [scheduling]
           initial cycle point = 2000
-          [[dependencies]]
-              [[[P1Y]]]
-                  graph = """
-                      @wall_clock => foo? => bar
-                      (foo? & bar) => pub
-                  """
+          [[graph]]
+              P1Y = """
+                  @wall_clock => foo? => bar
+                  (foo? & bar) => pub
+              """
+
+.. note::
+
+   The graph part should format the same as the ``cylc-graph`` example
+   below.
 
 ``cylc-graph``
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
* Closes https://github.com/cylc/cylc-sphinx-extensions/issues/6
* Graph settings used to begin `graph = ...`
* Now any setting in the `[[graph]]` section is a graph setting.