### PR TITLE
cylc_lang: permit preprocessing in intercycle offsets

### DIFF
--- a/cylc/sphinx_ext/cylc_lang/__init__.py
+++ b/cylc/sphinx_ext/cylc_lang/__init__.py
@@ -30,12 +30,20 @@ Lexer for the Cylc language and ``flow.cylc`` extensions.
 
    .. code-block:: cylc
 
+      # Jinja2
+
+      {% set final_cycle_point = final_cycle_point | default('') %}
+      {% set duration = duration | default('P1Y') %}
+
       [scheduling]
           initial cycle point = 2000
+          final cycle point = {{ final_cycle_point }}
           [[graph]]
               P1Y = """
                   @wall_clock => foo? => bar
                   (foo? & bar) => pub
+
+                  foo[-{{ duration }}+P1D] => foo
               """
 
 .. note::

--- a/cylc/sphinx_ext/cylc_lang/lexers.py
+++ b/cylc/sphinx_ext/cylc_lang/lexers.py
@@ -200,7 +200,33 @@ class CylcLexer(RegexLexer):
             include('integer-duration'),  # matches a subset of iso8601
             include('iso8601-duration'),
             (r'[\^\$]', INTERCYCLE_OFFSET_TOKEN),
+            (
+                # anything that contains Jinja2 syntax
+                r'(?=[^\]]*{{)',
+                INTERCYCLE_OFFSET_TOKEN,
+                'preproc-intercycle-offset',
+            ),
+            (
+                # anything that contains EmPy syntax
+                r'(?=[^\]]*@)',
+                INTERCYCLE_OFFSET_TOKEN,
+                'preproc-intercycle-offset',
+            ),
             (r'\]', Text, '#pop')
+        ],
+
+        # Task inter-cycle offset with preprocessing: foo[-{{duration}}+P1D]
+        # Note: This is done in its own section so that we don't bypass the
+        # validation that has been implemented for explicit offsets
+        'preproc-intercycle-offset': [
+            # permit pre-processing
+            include('preproc'),
+            # interpret all other text as part of the offset
+            # (we can't perform validation when preprocessing is involved)
+            (r'[^\]]', INTERCYCLE_OFFSET_TOKEN),
+            # the first "]" (outside of preprocessing) marks the end of the
+            # offset
+            (r'(?=\])', Text, '#pop')
         ],
 
         # generic Cylc cycle point:  2000


### PR DESCRIPTION
The lexer didn't permit preprocessing inside of inter-cycle offsets.

This caused the examples in https://github.com/cylc/cylc-flow/pull/6349 the be flagged as errors (which would have caused cylc-doc build failures).

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (example of preproc in intercycle offset now in the docs)
- [x] Changelog entry included - no changelog for this project
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix - no bugfix release branch for this project